### PR TITLE
fixed error in annotations finder regex and added some test cases for…

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function getRawAnnotations(fileContent, type, name){
         module: ['module\\.exports\\s*=\\s*{']
     })[type];
 
-    var regex = new RegExp('((\\/\\/.*)|(\\/\\*[\\S\\s]*\\*\\/)|\\s)*(' + suffixes.join('|') + ')');
+    var regex = new RegExp('((\\/\\/.*)|(\\/\\*(?:[\\s\\S](?!\\*\\/))*?\\s*\\*\\/)|\\s)*(' + suffixes.join('|') + ')');
 
     var matches = regex.exec(fileContent);
 

--- a/test/object-exports.js
+++ b/test/object-exports.js
@@ -92,6 +92,14 @@ describe('module exposing an object', function(){
                 result.functions.functionWithMultipleLineAnnotation.rawAnnotations.should.have.property('MultipleLine', ['MultipleLine()']);
             });
 
+            it('should not get the module annotation', function(){
+                result.functions.functionWithMultipleLineAnnotation.annotations.should.not.have.property('testModuleMultiline');
+            });
+
+            it('should not get the module rawannotation', function(){
+                result.functions.functionWithMultipleLineAnnotation.rawAnnotations.should.not.have.property('testModuleMultiline', ['testModuleMultiline()']);
+            });
+
             it('should have the function reference', function(){
                 result.functions.functionWithMultipleLineAnnotation.ref().should.be.equal('MultipleLine');
             });
@@ -126,6 +134,24 @@ describe('module exposing an object', function(){
             it('should get the third rawAnnotation', function(){
                 result.functions.functionWithALotOfAnnotation.rawAnnotations.should.have.property('Test3', ['Test3()']);
             });
+
+            it('should not get the module annotation', function(){
+                result.functions.functionWithALotOfAnnotation.annotations.should.not.have.property('testModuleMultiline');
+            });
+
+            it('should not get the module rawannotation', function(){
+                result.functions.functionWithALotOfAnnotation.rawAnnotations.should.not.have.property('testModuleMultiline', ['testModuleMultiline()']);
+            });
+
+            it('should not get the functionWithMultipleLineAnnotation annotation', function(){
+                result.functions.functionWithALotOfAnnotation.annotations.should.not.have.property('MultipleLine');
+            });
+
+            it('should not get the functionWithMultipleLineAnnotation rawannotation', function(){
+                result.functions.functionWithALotOfAnnotation.rawAnnotations.should.not.have.property('MultipleLine', ['MultipleLine()']);
+            });
+
+
 
             it('should have the function reference', function(){
                 result.functions.functionWithALotOfAnnotation.ref().should.be.equal('ALot');
@@ -262,6 +288,14 @@ describe('module exposing an object', function(){
                 result.functions.functionWithMultipleLineAnnotation.rawAnnotations.should.have.property('MultipleLine', ['MultipleLine()']);
             });
 
+            it('should not get the module annotation', function(){
+                result.functions.functionWithMultipleLineAnnotation.annotations.should.not.have.property('testModuleMultiline');
+            });
+
+            it('should not get the module rawannotation', function(){
+                result.functions.functionWithMultipleLineAnnotation.rawAnnotations.should.not.have.property('testModuleMultiline', ['testModuleMultiline()']);
+            });
+
             it('should have the function reference', function(){
                 result.functions.functionWithMultipleLineAnnotation.ref().should.be.equal('MultipleLine');
             });
@@ -295,6 +329,22 @@ describe('module exposing an object', function(){
 
             it('should get the third rawAnnotation', function(){
                 result.functions.functionWithALotOfAnnotation.rawAnnotations.should.have.property('Test3', ['Test3()']);
+            });
+
+            it('should not get the module annotation', function(){
+                result.functions.functionWithALotOfAnnotation.annotations.should.not.have.property('testModuleMultiline');
+            });
+
+            it('should not get the module rawannotation', function(){
+                result.functions.functionWithALotOfAnnotation.rawAnnotations.should.not.have.property('testModuleMultiline', ['testModuleMultiline()']);
+            });
+
+            it('should not get the functionWithMultipleLineAnnotation annotation', function(){
+                result.functions.functionWithALotOfAnnotation.annotations.should.not.have.property('MultipleLine');
+            });
+
+            it('should not get the functionWithMultipleLineAnnotation rawannotation', function(){
+                result.functions.functionWithALotOfAnnotation.rawAnnotations.should.not.have.property('MultipleLine', ['MultipleLine()']);
             });
 
             it('should have the function reference', function(){


### PR DESCRIPTION
fixed bug for cases which extra annotations are included in function annotations. for example in the code below BadAnnotation is included in test2 annotations.
```
/*
 * @BadAnnotation('a')
*/
module.export.test = function(){
}
/*
* @Annotation2('b')
*/
///@Annotation3('c')
/**
* @Annotation4('d')
*/
module.export.test2 = function(){
}
```