### PR TITLE
Function export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# intellij project
+.idea/
+

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function getAnnotationFromFile(absolutePath, filePath, fileContent){
 function getRawAnnotations(fileContent, type, name){
     suffixes = ({
         function: [name + '\\s*:\\s*function\\(', '(module\\.)?exports\\.' + name + '\\s*=\\s*'],
-        module: ['module\\.exports\\s*=\\s*{']
+        module: ['module\\.exports\\s*=\\s*(:?function\\([\\S\\s]*?\\))?\\s*{']
     })[type];
 
     var regex = new RegExp('((\\/\\/.*)|(\\/\\*(?:[\\s\\S](?!\\*\\/))*?\\s*\\*\\/)|\\s)*(' + suffixes.join('|') + ')');

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function getRawAnnotations(fileContent, type, name){
         module: ['module\\.exports\\s*=\\s*{']
     })[type];
 
-    var regex = new RegExp('((\\/\\/.*)|(\\/\\*[\\S\\s]*\\*\\/)|\\s)*(' + suffixes.join('|') + ')');
+    var regex = new RegExp('((\\/\\/.*)|(\\/\\*(?:[\\s\\S](?!\\*\\/))*?\\s*\\*\\/)|\\s)*(' + suffixes.join('|') + ')');
 
     var matches = regex.exec(fileContent);
 

--- a/test/fixtures/moduleFunctionMock.js
+++ b/test/fixtures/moduleFunctionMock.js
@@ -1,0 +1,9 @@
+
+// @module()
+/*
+ @testModuleMultiline()
+ */
+module.exports = function(){
+    return "test";
+};
+

--- a/test/function-module-export.js
+++ b/test/function-module-export.js
@@ -1,0 +1,74 @@
+var should = require('should');
+
+var annotationModule = require('../index.js');
+
+var mockPath = './fixtures/moduleFunctionMock.js';
+
+
+describe('module exposing functions', function(){
+
+    describe('asynchronous', function() {
+
+        var err;
+        var result;
+
+        before(function(done){
+            annotationModule(mockPath, function(e, a){
+                err = e;
+                result = a;
+
+                done();
+            });
+        });
+
+        it('should get the multiline annotation', function(){
+            result.module.annotations.should.have.property('testModuleMultiline');
+        });
+
+        it('should get the multiline raw annotation', function(){
+            result.module.rawAnnotations.should.have.property('testModuleMultiline', ['testModuleMultiline()']);
+        });
+
+        it('should get the module annotation', function(){
+            result.module.annotations.should.have.property('module');
+        });
+
+        it('should get the module annotation', function(){
+            result.module.rawAnnotations.should.have.property('module', ['module()']);
+        });
+    });
+
+
+
+
+    describe('asynchronous', function() {
+
+        var err;
+        var result;
+
+        before(function(){
+
+            try {
+                result = annotationModule.sync(mockPath);
+            } catch (e) {
+                err = e;
+            }
+        });
+
+        it('should get the multiline annotation', function(){
+            result.module.annotations.should.have.property('testModuleMultiline');
+        });
+
+        it('should get the multiline raw annotation', function(){
+            result.module.rawAnnotations.should.have.property('testModuleMultiline', ['testModuleMultiline()']);
+        });
+
+        it('should get the module annotation', function(){
+            result.module.annotations.should.have.property('module');
+        });
+
+        it('should get the module annotation', function(){
+            result.module.rawAnnotations.should.have.property('module', ['module()']);
+        });
+    });
+});

--- a/test/object-exports.js
+++ b/test/object-exports.js
@@ -92,6 +92,14 @@ describe('module exposing an object', function(){
                 result.functions.functionWithMultipleLineAnnotation.rawAnnotations.should.have.property('MultipleLine', ['MultipleLine()']);
             });
 
+            it('should not get the module annotation', function(){
+                result.functions.functionWithMultipleLineAnnotation.annotations.should.not.have.property('testModuleMultiline');
+            });
+
+            it('should not get the module rawannotation', function(){
+                result.functions.functionWithMultipleLineAnnotation.rawAnnotations.should.not.have.property('testModuleMultiline', ['testModuleMultiline()']);
+            });
+
             it('should have the function reference', function(){
                 result.functions.functionWithMultipleLineAnnotation.ref().should.be.equal('MultipleLine');
             });
@@ -126,6 +134,24 @@ describe('module exposing an object', function(){
             it('should get the third rawAnnotation', function(){
                 result.functions.functionWithALotOfAnnotation.rawAnnotations.should.have.property('Test3', ['Test3()']);
             });
+
+            it('should not get the module annotation', function(){
+                result.functions.functionWithALotOfAnnotation.annotations.should.not.have.property('testModuleMultiline');
+            });
+
+            it('should not get the module rawannotation', function(){
+                result.functions.functionWithALotOfAnnotation.rawAnnotations.should.not.have.property('testModuleMultiline', ['testModuleMultiline()']);
+            });
+
+            it('should not get the functionWithMultipleLineAnnotation annotation', function(){
+                result.functions.functionWithALotOfAnnotation.annotations.should.not.have.property('MultipleLine');
+            });
+
+            it('should not get the functionWithMultipleLineAnnotation rawannotation', function(){
+                result.functions.functionWithALotOfAnnotation.rawAnnotations.should.not.have.property('MultipleLine', ['MultipleLine()']);
+            });
+
+
 
             it('should have the function reference', function(){
                 result.functions.functionWithALotOfAnnotation.ref().should.be.equal('ALot');
@@ -262,6 +288,14 @@ describe('module exposing an object', function(){
                 result.functions.functionWithMultipleLineAnnotation.rawAnnotations.should.have.property('MultipleLine', ['MultipleLine()']);
             });
 
+            it('should not get the module annotation', function(){
+                result.functions.functionWithMultipleLineAnnotation.annotations.should.not.have.property('testModuleMultiline');
+            });
+
+            it('should not get the module rawannotation', function(){
+                result.functions.functionWithMultipleLineAnnotation.rawAnnotations.should.not.have.property('testModuleMultiline', ['testModuleMultiline()']);
+            });
+
             it('should have the function reference', function(){
                 result.functions.functionWithMultipleLineAnnotation.ref().should.be.equal('MultipleLine');
             });
@@ -295,6 +329,22 @@ describe('module exposing an object', function(){
 
             it('should get the third rawAnnotation', function(){
                 result.functions.functionWithALotOfAnnotation.rawAnnotations.should.have.property('Test3', ['Test3()']);
+            });
+
+            it('should not get the module annotation', function(){
+                result.functions.functionWithALotOfAnnotation.annotations.should.not.have.property('testModuleMultiline');
+            });
+
+            it('should not get the module rawannotation', function(){
+                result.functions.functionWithALotOfAnnotation.rawAnnotations.should.not.have.property('testModuleMultiline', ['testModuleMultiline()']);
+            });
+
+            it('should not get the functionWithMultipleLineAnnotation annotation', function(){
+                result.functions.functionWithALotOfAnnotation.annotations.should.not.have.property('MultipleLine');
+            });
+
+            it('should not get the functionWithMultipleLineAnnotation rawannotation', function(){
+                result.functions.functionWithALotOfAnnotation.rawAnnotations.should.not.have.property('MultipleLine', ['MultipleLine()']);
             });
 
             it('should have the function reference', function(){


### PR DESCRIPTION
now it supports finding annotations for modules like this:
```
module.exports = function(){

}
```